### PR TITLE
Fix module for GitConfigParser

### DIFF
--- a/lib/smart_todo/git_config_parser.rb
+++ b/lib/smart_todo/git_config_parser.rb
@@ -1,36 +1,40 @@
-class GitConfigParser
-  GIT_CONFIG_PATH = ".git/config"
+# frozen_string_literal: true
 
-  def initialize
-    @config = {}
-    parse(GIT_CONFIG_PATH) if File.exist?(GIT_CONFIG_PATH)
-  end
+module SmartTodo
+  class GitConfigParser
+    GIT_CONFIG_PATH = ".git/config"
 
-  def parse(file_path)
-    current_section = nil
-    File.readlines(file_path).each do |line|
-      line = line.strip
+    def initialize
+      @config = {}
+      parse(GIT_CONFIG_PATH) if File.exist?(GIT_CONFIG_PATH)
+    end
 
-      if line.start_with?("[") && line.end_with?("]")
-        current_section = line[1...-1]
-        @config[current_section] = {}
-      elsif current_section && line.include?("=")
-        key, value = line.split("=", 2).map(&:strip)
-        @config[current_section][key] = value
+    def parse(file_path)
+      current_section = nil
+      File.readlines(file_path).each do |line|
+        line = line.strip
+
+        if line.start_with?("[") && line.end_with?("]")
+          current_section = line[1...-1]
+          @config[current_section] = {}
+        elsif current_section && line.include?("=")
+          key, value = line.split("=", 2).map(&:strip)
+          @config[current_section][key] = value
+        end
       end
     end
-  end
 
-  def read_value(section, key)
-    return @config[section][key] if @config.key?(section) && @config[section].key?(key)
+    def read_value(section, key)
+      return @config[section][key] if @config.key?(section) && @config[section].key?(key)
 
-    nil
-  end
+      nil
+    end
 
-  # Github defined as following in repository config
-  # git@git.domain.com:organization/repo.git
-  # TODO Gitlab and Bitbucket urls are slightly different so it wont work for them as of yet
-  def github_repo_url
-    "https://" + self.read_value('remote "origin"', 'url').split('@').last.gsub(':', '/').gsub(/\.git$/, "") + "/blob/HEAD/"
+    # Github defined as following in repository config
+    # git@git.domain.com:organization/repo.git
+    # TODO Gitlab and Bitbucket urls are slightly different so it wont work for them as of yet
+    def github_repo_url
+      "https://" + self.read_value('remote "origin"', 'url').split('@').last.gsub(':', '/').gsub(/\.git$/, "") + "/blob/HEAD/"
+    end
   end
 end

--- a/test/smart_todo/git_config_parser_test.rb
+++ b/test/smart_todo/git_config_parser_test.rb
@@ -2,49 +2,51 @@
 
 require "test_helper"
 
-class GitConfigParserTest < Minitest::Test
-  def setup
-    @test_config_content = <<~HEREDOC
-      [remote "origin"]
-        url = git@github.com:org_name/repo_name.git
-      [user]
-        name = John Doe
-        email = john@example.com
-    HEREDOC
-  end
-
-  def test_initialize_parses_git_config_file
-    File.stub(:exist?, true) do
-      File.stub(:readlines, @test_config_content.lines) do
-        assert_equal({
-          'remote "origin"' => { 'url' => 'git@github.com:org_name/repo_name.git' },
-          'user' => { 'name' => 'John Doe', 'email' => 'john@example.com' }
-        }, GitConfigParser.new.instance_variable_get(:@config))
-      end
+module SmartTodo
+  class GitConfigParserTest < Minitest::Test
+    def setup
+      @test_config_content = <<~HEREDOC
+        [remote "origin"]
+          url = git@github.com:org_name/repo_name.git
+        [user]
+          name = John Doe
+          email = john@example.com
+      HEREDOC
     end
-  end
 
-  def test_read_value_returns_value_for_given_section_and_key
-    File.stub(:exist?, true) do
-      File.stub(:readlines, @test_config_content.lines) do
-        assert_equal('git@github.com:org_name/repo_name.git', GitConfigParser.new.read_value('remote "origin"', 'url'))
+    def test_initialize_parses_git_config_file
+      File.stub(:exist?, true) do
+        File.stub(:readlines, @test_config_content.lines) do
+          assert_equal({
+            'remote "origin"' => { 'url' => 'git@github.com:org_name/repo_name.git' },
+            'user' => { 'name' => 'John Doe', 'email' => 'john@example.com' }
+          }, GitConfigParser.new.instance_variable_get(:@config))
+        end
       end
     end
 
-  end
+    def test_read_value_returns_value_for_given_section_and_key
+      File.stub(:exist?, true) do
+        File.stub(:readlines, @test_config_content.lines) do
+          assert_equal('git@github.com:org_name/repo_name.git', GitConfigParser.new.read_value('remote "origin"', 'url'))
+        end
+      end
 
-  def test_read_value_returns_nil_for_nonexistent_section_or_key
-     File.stub(:exist?, true) do
-      File.stub(:readlines, @test_config_content.lines) do
-        assert_nil(GitConfigParser.new.read_value('nonexistent_section', 'nonexistent_key'))
+    end
+
+    def test_read_value_returns_nil_for_nonexistent_section_or_key
+      File.stub(:exist?, true) do
+        File.stub(:readlines, @test_config_content.lines) do
+          assert_nil(GitConfigParser.new.read_value('nonexistent_section', 'nonexistent_key'))
+        end
       end
     end
-  end
 
-  def test_github_repo_url_returns_correct_github_repository_url
-     File.stub(:exist?, true) do
-      File.stub(:readlines, @test_config_content.lines) do
-        assert_equal('https://github.com/org_name/repo_name/blob/HEAD/', GitConfigParser.new.github_repo_url)
+    def test_github_repo_url_returns_correct_github_repository_url
+      File.stub(:exist?, true) do
+        File.stub(:readlines, @test_config_content.lines) do
+          assert_equal('https://github.com/org_name/repo_name/blob/HEAD/', GitConfigParser.new.github_repo_url)
+        end
       end
     end
   end


### PR DESCRIPTION
`GitConfigParser` is supposed to go into the `SmartTodo` module. The tests are currently failing because of this:

```
…/test/smart_todo/dispatchers/output_test.rb:39: warning:
Expected smart_todo/git_config_parser to define
SmartTodo::GitConfigParser but it didn't
```

> [!tip]
> Review [without whitespace](https://github.com/nxt-insurance/smart_todo/pull/3/files?w=1).
