### PR TITLE
Allow prism 1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,52 +2,61 @@ PATH
   remote: .
   specs:
     smart_todo (1.7.2)
-      prism (~> 0.15)
+      prism (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    ast (2.4.2)
-    crack (0.4.5)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    ast (2.4.3)
+    bigdecimal (3.1.9)
+    crack (1.0.0)
+      bigdecimal
       rexml
-    hashdiff (1.0.1)
-    json (2.6.3)
-    minitest (5.14.4)
-    parallel (1.23.0)
-    parser (3.2.2.3)
+    hashdiff (1.1.2)
+    json (2.10.2)
+    language_server-protocol (3.17.0.4)
+    lint_roller (1.1.0)
+    minitest (5.25.5)
+    parallel (1.26.3)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
-    prism (0.20.0)
-    public_suffix (4.0.6)
-    racc (1.7.0)
+    prism (1.4.0)
+    public_suffix (6.0.1)
+    racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.8.1)
-    rexml (3.2.5)
-    rubocop (1.52.1)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
+    rexml (3.4.1)
+    rubocop (1.75.2)
       json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.3)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.29.0)
-      parser (>= 3.2.1.0)
-    rubocop-shopify (2.14.0)
-      rubocop (~> 1.51)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.44.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-shopify (2.16.0)
+      rubocop (~> 1.62)
     ruby-progressbar (1.13.0)
-    unicode-display_width (2.4.2)
-    webmock (3.11.2)
-      addressable (>= 2.3.6)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
@@ -59,4 +68,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.25
+   2.6.2

--- a/smart_todo.gemspec
+++ b/smart_todo.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ["smart_todo"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency("prism", "~> 0.15")
+  spec.add_runtime_dependency("prism", "~> 1.0")
   spec.add_development_dependency("bundler", ">= 1.17")
   spec.add_development_dependency("minitest", "~> 5.0")
   spec.add_development_dependency("rake", ">= 10.0")


### PR DESCRIPTION
Prism was locked to `0.x`, but the most recent version of Prism (which rubocop depends on) should be allowed, too.