### PR TITLE
Fix Rubocop offenses

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "rubocop/rake_task"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -9,4 +10,6 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
-task(default: :test)
+RuboCop::RakeTask.new
+
+task(default: [:test, :rubocop])

--- a/lib/smart_todo/cli.rb
+++ b/lib/smart_todo/cli.rb
@@ -66,7 +66,7 @@ module SmartTodo
         opts.on("--dispatcher DISPATCHER") do |dispatcher|
           @options[:dispatcher] = dispatcher
         end
-        opts.on("--read-repository-config") do |repository_config|
+        opts.on("--read-repository-config") do |_repository_config|
           @options[:repository_config] = GitConfigParser.new
         end
       end

--- a/lib/smart_todo/dispatchers/base.rb
+++ b/lib/smart_todo/dispatchers/base.rb
@@ -93,7 +93,7 @@ module SmartTodo
       end
 
       def filepath_or_url
-        if  @options.has_key? :repository_config
+        if @options.key?(:repository_config)
           return @options[:repository_config].github_repo_url + @file
         end
 

--- a/lib/smart_todo/git_config_parser.rb
+++ b/lib/smart_todo/git_config_parser.rb
@@ -34,7 +34,10 @@ module SmartTodo
     # git@git.domain.com:organization/repo.git
     # TODO Gitlab and Bitbucket urls are slightly different so it wont work for them as of yet
     def github_repo_url
-      "https://" + self.read_value('remote "origin"', 'url').split('@').last.gsub(':', '/').gsub(/\.git$/, "") + "/blob/HEAD/"
+      "https://" + read_value('remote "origin"', "url").split("@").last.gsub(":", "/").gsub(
+        /\.git$/,
+        "",
+      ) + "/blob/HEAD/"
     end
   end
 end

--- a/smart_todo.gemspec
+++ b/smart_todo.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/nxt_insurance/smart_todo"
   spec.license       = "MIT"
 
-  spec.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/nxt-insurance'
+  spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/nxt-insurance"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = spec.homepage + "/releases"

--- a/test/smart_todo/cli_test.rb
+++ b/test/smart_todo/cli_test.rb
@@ -169,7 +169,16 @@ module SmartTodo
           assert_output(".") do
             assert_equal(
               0,
-              cli.run([file.path, "--slack_token", "123", "--fallback_channel", '#general"', "--dispatcher", "slack", "--read-repository-config"]),
+              cli.run([
+                file.path,
+                "--slack_token",
+                "123",
+                "--fallback_channel",
+                '#general"',
+                "--dispatcher",
+                "slack",
+                "--read-repository-config",
+              ]),
             )
           end
         end

--- a/test/smart_todo/git_config_parser_test.rb
+++ b/test/smart_todo/git_config_parser_test.rb
@@ -17,10 +17,13 @@ module SmartTodo
     def test_initialize_parses_git_config_file
       File.stub(:exist?, true) do
         File.stub(:readlines, @test_config_content.lines) do
-          assert_equal({
-            'remote "origin"' => { 'url' => 'git@github.com:org_name/repo_name.git' },
-            'user' => { 'name' => 'John Doe', 'email' => 'john@example.com' }
-          }, GitConfigParser.new.instance_variable_get(:@config))
+          assert_equal(
+            {
+              'remote "origin"' => { "url" => "git@github.com:org_name/repo_name.git" },
+              "user" => { "name" => "John Doe", "email" => "john@example.com" },
+            },
+            GitConfigParser.new.instance_variable_get(:@config),
+          )
         end
       end
     end
@@ -28,16 +31,18 @@ module SmartTodo
     def test_read_value_returns_value_for_given_section_and_key
       File.stub(:exist?, true) do
         File.stub(:readlines, @test_config_content.lines) do
-          assert_equal('git@github.com:org_name/repo_name.git', GitConfigParser.new.read_value('remote "origin"', 'url'))
+          assert_equal(
+            "git@github.com:org_name/repo_name.git",
+            GitConfigParser.new.read_value('remote "origin"', "url"),
+          )
         end
       end
-
     end
 
     def test_read_value_returns_nil_for_nonexistent_section_or_key
       File.stub(:exist?, true) do
         File.stub(:readlines, @test_config_content.lines) do
-          assert_nil(GitConfigParser.new.read_value('nonexistent_section', 'nonexistent_key'))
+          assert_nil(GitConfigParser.new.read_value("nonexistent_section", "nonexistent_key"))
         end
       end
     end
@@ -45,7 +50,7 @@ module SmartTodo
     def test_github_repo_url_returns_correct_github_repository_url
       File.stub(:exist?, true) do
         File.stub(:readlines, @test_config_content.lines) do
-          assert_equal('https://github.com/org_name/repo_name/blob/HEAD/', GitConfigParser.new.github_repo_url)
+          assert_equal("https://github.com/org_name/repo_name/blob/HEAD/", GitConfigParser.new.github_repo_url)
         end
       end
     end


### PR DESCRIPTION
This fixes the Rubocop offenses (using safe autocorrect, i.e. `--autocorrect`).

Additionally, it makes the default Rake task run Rubocop, so that we don’t run into the issue in the future that we’ve skipped running Rubocop.
